### PR TITLE
AnimatorOverrideController, AnimationController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 debug/
 target/
 Cargo.lock
+.DS_Store

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 
 use anyhow::{bail, Result};
 use binrw::meta::{EndianKind, ReadEndian, WriteEndian};
-use binrw::{binread, binrw, BinRead, BinResult, BinWrite, Endian, NullString};
+use binrw::{binread, binrw, until_eof, BinRead, BinResult, BinWrite, Endian, NullString};
 use byteorder::{BigEndian, WriteBytesExt};
 use encoding_rs::UTF_8;
 use itertools::{izip, Itertools};
@@ -29,6 +29,8 @@ pub const SPRITE_HASH: i128 = 45701628647153051529734544331337206412;
 pub const SPRITE_ATLAS_HASH: i128 = -21517008777126347833343678527744186422;
 pub const TERRAIN_MONO_BEHAVIOR_TYPE_HASH: i128 = 161821592088346330348225465071444734321;
 pub const ANIMATION_CLIP_HASH: i128 = -80937412517696055409803870673809846754;
+pub const ANIMATOR_OVERRIDE_CONTROLLER_HASH: i128 = -102229199973352171437435367599983726207;
+pub const ANIMATOR_CONTROLLER_HASH: i128 = -115873685307230980538653717616089922820;
 
 fn write_padding<W: Write + Seek>(writer: &mut W, align: u64) -> BinResult<()> {
     while writer.stream_position()? % align != 0 {
@@ -52,11 +54,11 @@ pub struct AssetFile {
     #[br(align_after = 4, temp)]
     object_count: u32,
     #[br(count = object_count, temp)]
-    objects: Vec<AssetFileObject>,
+    pub objects: Vec<AssetFileObject>,
     #[br(calc = objects.iter().map(|obj| obj.path_id).collect())]
-    path_ids: Vec<u64>,
+    pub path_ids: Vec<u64>,
     #[br(calc = calculate_object_order(&objects))]
-    object_order: Vec<usize>,
+    pub object_order: Vec<usize>,
 
     #[br(temp)]
     script_count: u32,
@@ -496,6 +498,8 @@ pub enum Asset {
     SpringJob(MonoBehavior<SpringJob>),
     SpringBone(MonoBehavior<SpringBone>),
     AnimationClip(AnimationClip),
+    AnimatorOverrideController(AnimatorOverrideController),
+    AnimatorController(AnimatorController),
     Unparsed(Unparsed),
 }
 
@@ -522,6 +526,8 @@ impl Asset {
             Asset::SpringJob(_) => SPRING_JOB_MONO_BEHAVIOR_HASH,
             Asset::SpringBone(_) => SPRING_BONE_MONO_BEHAVIOR_HASH,
             Asset::AnimationClip(_) => ANIMATION_CLIP_HASH,
+            Asset::AnimatorOverrideController(_) => ANIMATOR_OVERRIDE_CONTROLLER_HASH,
+            Asset::AnimatorController(_) => ANIMATOR_CONTROLLER_HASH,
             Asset::Unparsed(blob) => blob.type_hash,
         }
     }
@@ -573,7 +579,13 @@ impl BinRead for Asset {
             }
             ANIMATION_CLIP_HASH => {
                 AnimationClip::read_options(reader, endian, ()).map(Self::AnimationClip)
-             }
+            }
+            ANIMATOR_OVERRIDE_CONTROLLER_HASH => {
+                AnimatorOverrideController::read_options(reader, endian, ()).map(Self::AnimatorOverrideController)
+            }
+            ANIMATOR_CONTROLLER_HASH => {
+                AnimatorController::read_options(reader, endian, ()).map(Self::AnimatorController)
+            }
             _ => {
                 let mut blob = vec![0; size];
                 reader.read_exact(&mut blob)?;
@@ -2091,4 +2103,29 @@ pub struct AnimationEvent {
     pub float_parameter: f32,
     pub int_parameter: i32,
     pub message_options: i32
+}
+
+#[binrw]
+#[derive(Debug)]
+pub struct AnimatorOverrideController {
+    pub name: UString,
+    #[brw(align_before = 4)]
+    pub controller: PPtr,
+    pub clips: UArray<AnimationClipOverride>,
+}
+
+#[binrw]
+#[derive(Debug)]
+pub struct AnimationClipOverride {
+    pub original_clip: PPtr,
+    pub override_clip: PPtr,
+}
+
+#[binrw]
+#[derive(Debug)]
+pub struct AnimatorController {
+    pub name: UString,
+    // read to end of file
+    #[br(parse_with = until_eof)]
+    data: Vec<u8>,
 }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -54,11 +54,11 @@ pub struct AssetFile {
     #[br(align_after = 4, temp)]
     object_count: u32,
     #[br(count = object_count, temp)]
-    pub objects: Vec<AssetFileObject>,
+    objects: Vec<AssetFileObject>,
     #[br(calc = objects.iter().map(|obj| obj.path_id).collect())]
     pub path_ids: Vec<u64>,
     #[br(calc = calculate_object_order(&objects))]
-    pub object_order: Vec<usize>,
+    object_order: Vec<usize>,
 
     #[br(temp)]
     script_count: u32,
@@ -2109,7 +2109,6 @@ pub struct AnimationEvent {
 #[derive(Debug)]
 pub struct AnimatorOverrideController {
     pub name: UString,
-    #[brw(align_before = 4)]
     pub controller: PPtr,
     pub clips: UArray<AnimationClipOverride>,
 }
@@ -2125,7 +2124,7 @@ pub struct AnimationClipOverride {
 #[derive(Debug)]
 pub struct AnimatorController {
     pub name: UString,
-    // read to end of file
+    // Body yet needed
     #[br(parse_with = until_eof)]
     data: Vec<u8>,
 }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -2124,7 +2124,7 @@ pub struct AnimationClipOverride {
 #[derive(Debug)]
 pub struct AnimatorController {
     pub name: UString,
-    // Body yet needed
+    // Body not yet needed
     #[br(parse_with = until_eof)]
     data: Vec<u8>,
 }


### PR DESCRIPTION
### Changes

1. Added support for the `AnimatorOverrideController`
2. Added one field needed for `AnimatorController`. The rest of the fields will be provided in a future PR.
3. Exposed `AssetFile`'s `path_ids` for dependency patching purposes.

### How it was tested

Tested end-to-end, creating a custom `AnimatorOverrideController` dependency.

### Question
Was it OK to use `#[br(parse_with = until_eof)]` for `AnimatorController` this way?


If it is OK, and there are no other issues, then this is ready to merge.

Thanks!